### PR TITLE
fix #24

### DIFF
--- a/.idea/modules/oauth2-essentials.iml
+++ b/.idea/modules/oauth2-essentials.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="oauth2-essentials" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="oauth2-essentials" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/oauth2-essentials_main.iml
+++ b/.idea/modules/oauth2-essentials_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="oauth2-essentials:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="oauth2-essentials:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />
@@ -14,7 +14,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Gradle: net.iharder:base64:2.3.9" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:http-client-essentials:0.10" level="project" />
-    <orderEntry type="library" name="Gradle: org.dmfs:http-client-headers:0.10" level="project" />
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
@@ -24,12 +23,14 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="library" name="Gradle: org.dmfs:http-client-headers:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:http-client-types:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:http-client-basics:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:http-executor-decorators:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:rfc5545-datetime:0.2.4" level="project" />
     <orderEntry type="library" name="Gradle: org.json:json:20160212" level="project" />
-    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:rfc3986-uri:0.1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3.1" level="project" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>

--- a/.idea/modules/oauth2-essentials_test.iml
+++ b/.idea/modules/oauth2-essentials_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="oauth2-essentials:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="oauth2-essentials:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />
@@ -27,11 +27,12 @@
     <orderEntry type="library" name="Gradle: org.dmfs:http-executor-decorators:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:rfc5545-datetime:0.2.4" level="project" />
     <orderEntry type="library" name="Gradle: org.json:json:20160212" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:rfc3986-uri:0.1.3" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:http-client-mockutils:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.jmockit:jmockit:1.27" level="project" />
-    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3.1" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="oauth2-essentials_main" />
 </module>

--- a/.idea/modules/oauth2-providers/oauth2-providers.iml
+++ b/.idea/modules/oauth2-providers/oauth2-providers.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":oauth2-providers" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":oauth2-providers" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../oauth2-providers">

--- a/.idea/modules/oauth2-providers/oauth2-providers_main.iml
+++ b/.idea/modules/oauth2-providers/oauth2-providers_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":oauth2-providers:main" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":oauth2-providers:main" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../oauth2-providers/build/classes/main" />
     <exclude-output />
@@ -18,6 +18,7 @@
     <orderEntry type="library" name="Gradle: org.dmfs:http-executor-decorators:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:rfc5545-datetime:0.2.4" level="project" />
     <orderEntry type="library" name="Gradle: org.json:json:20160212" level="project" />
-    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:rfc3986-uri:0.1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3.1" level="project" />
   </component>
 </module>

--- a/.idea/modules/oauth2-providers/oauth2-providers_test.iml
+++ b/.idea/modules/oauth2-providers/oauth2-providers_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":oauth2-providers:test" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.4.3-20-gf24c17c" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":oauth2-providers:test" external.linked.project.path="$MODULE_DIR$/../../../oauth2-providers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.5.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../oauth2-providers/build/classes/test" />
     <exclude-output />
@@ -21,8 +21,9 @@
     <orderEntry type="library" name="Gradle: org.dmfs:http-executor-decorators:0.10" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:rfc5545-datetime:0.2.4" level="project" />
     <orderEntry type="library" name="Gradle: org.json:json:20160212" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:rfc3986-uri:0.1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3.1" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="oauth2-providers_main" />
 </module>

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     compile 'org.dmfs:http-executor-decorators:' + HTTP_CLIENT_ESSENTIALS_VERSION
     compile 'org.dmfs:rfc5545-datetime:0.2.4'
     compile 'org.json:json:20160212'
+    compile 'org.dmfs:rfc3986-uri:0.1.3'
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.dmfs:http-client-mockutils:' + HTTP_CLIENT_ESSENTIALS_VERSION
     testCompile 'org.jmockit:jmockit:1.27'

--- a/src/main/java/org/dmfs/oauth2/client/BasicOAuth2AuthCodeAuthorization.java
+++ b/src/main/java/org/dmfs/oauth2/client/BasicOAuth2AuthCodeAuthorization.java
@@ -22,8 +22,7 @@ import org.dmfs.httpessentials.parameters.BasicParameterType;
 import org.dmfs.httpessentials.parameters.ParameterType;
 import org.dmfs.httpessentials.parameters.Parametrized;
 import org.dmfs.httpessentials.types.UrlFormEncodedKeyValues;
-
-import java.net.URI;
+import org.dmfs.rfc3986.Uri;
 
 
 /**
@@ -44,9 +43,9 @@ public final class BasicOAuth2AuthCodeAuthorization implements OAuth2AuthCodeAut
     private final OAuth2Scope mScope;
 
 
-    public BasicOAuth2AuthCodeAuthorization(URI redirectUri, OAuth2Scope requestedScope, String state) throws ProtocolException
+    public BasicOAuth2AuthCodeAuthorization(Uri redirectUri, OAuth2Scope requestedScope, String state) throws ProtocolException
     {
-        mFragment = new UrlFormEncodedKeyValues(redirectUri.getRawQuery());
+        mFragment = new UrlFormEncodedKeyValues(redirectUri.query().toString());
         if (!state.equals(mFragment.firstParameter(STATE, "").value()))
         {
             throw new ProtocolException("State in redirect uri doesn't match the original state!");

--- a/src/main/java/org/dmfs/oauth2/client/BasicOAuth2AuthorizationRequest.java
+++ b/src/main/java/org/dmfs/oauth2/client/BasicOAuth2AuthorizationRequest.java
@@ -19,6 +19,7 @@ package org.dmfs.oauth2.client;
 import org.dmfs.oauth2.client.http.entities.XWwwFormUrlEncodedEntity;
 import org.dmfs.oauth2.client.pkce.PkceCodeChallenge;
 import org.dmfs.oauth2.client.utils.ImmutableEntry;
+import org.dmfs.rfc3986.Uri;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -63,9 +64,9 @@ public final class BasicOAuth2AuthorizationRequest implements OAuth2Authorizatio
 
 
     @Override
-    public OAuth2AuthorizationRequest withRedirectUri(URI redirectUri)
+    public OAuth2AuthorizationRequest withRedirectUri(Uri redirectUri)
     {
-        return withEntry(new ImmutableEntry("redirect_uri", redirectUri.toASCIIString()));
+        return withEntry(new ImmutableEntry("redirect_uri", redirectUri.toString()));
     }
 
 

--- a/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
+++ b/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
@@ -25,6 +25,7 @@ import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
 import org.dmfs.httpessentials.executors.useragent.Branded;
 import org.dmfs.httpessentials.types.Product;
 import org.dmfs.httpessentials.types.VersionedProduct;
+import org.dmfs.rfc3986.Uri;
 import org.dmfs.rfc5545.Duration;
 
 import java.io.IOException;
@@ -44,10 +45,10 @@ public final class BasicOAuth2Client implements OAuth2Client
 
     private final OAuth2AuthorizationProvider mProvider;
     private final OAuth2ClientCredentials mCredentials;
-    private final URI mRedirectUri;
+    private final Uri mRedirectUri;
 
 
-    public BasicOAuth2Client(OAuth2AuthorizationProvider provider, OAuth2ClientCredentials credentials, URI redirectUri)
+    public BasicOAuth2Client(OAuth2AuthorizationProvider provider, OAuth2ClientCredentials credentials, Uri redirectUri)
     {
         mProvider = provider;
         mCredentials = credentials;
@@ -72,7 +73,7 @@ public final class BasicOAuth2Client implements OAuth2Client
 
 
     @Override
-    public URI redirectUri()
+    public Uri redirectUri()
     {
         return mRedirectUri;
     }

--- a/src/main/java/org/dmfs/oauth2/client/OAuth2AuthorizationRequest.java
+++ b/src/main/java/org/dmfs/oauth2/client/OAuth2AuthorizationRequest.java
@@ -17,6 +17,7 @@
 package org.dmfs.oauth2.client;
 
 import org.dmfs.oauth2.client.pkce.PkceCodeChallenge;
+import org.dmfs.rfc3986.Uri;
 
 import java.net.URI;
 
@@ -47,7 +48,7 @@ public interface OAuth2AuthorizationRequest
      *
      * @return A new {@link OAuth2AuthorizationRequest} with the updated value.
      */
-    OAuth2AuthorizationRequest withRedirectUri(URI redirectUri);
+    OAuth2AuthorizationRequest withRedirectUri(Uri redirectUri);
 
     /**
      * Creates a new {@link OAuth2AuthorizationRequest} using the given {@link PkceCodeChallenge}.

--- a/src/main/java/org/dmfs/oauth2/client/OAuth2Client.java
+++ b/src/main/java/org/dmfs/oauth2/client/OAuth2Client.java
@@ -22,6 +22,7 @@ import org.dmfs.httpessentials.exceptions.ProtocolError;
 import org.dmfs.httpessentials.exceptions.ProtocolException;
 import org.dmfs.httpessentials.exceptions.RedirectionException;
 import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
+import org.dmfs.rfc3986.Uri;
 import org.dmfs.rfc5545.Duration;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ public interface OAuth2Client
      * @throws ProtocolError
      * @throws ProtocolException
      */
-    public OAuth2AccessToken accessToken(HttpRequest<OAuth2AccessToken> tokenRequest, HttpRequestExecutor executor) throws RedirectionException,
+    OAuth2AccessToken accessToken(HttpRequest<OAuth2AccessToken> tokenRequest, HttpRequestExecutor executor) throws RedirectionException,
             UnexpectedStatusException, IOException, ProtocolError, ProtocolException;
 
     /**
@@ -63,26 +64,26 @@ public interface OAuth2Client
      *
      * @return The URL that needs to be opened in a user agent.
      */
-    public URI authorizationUrl(OAuth2AuthorizationRequest authorizationRequest);
+    URI authorizationUrl(OAuth2AuthorizationRequest authorizationRequest);
 
     /**
      * Generates a random state String to be used in interactive grants.
      *
      * @return A random {@link String}.
      */
-    public String generatedRandomState();
+    String generatedRandomState();
 
     /**
      * The redirect URI of this client as registered with the server.
      *
      * @return A {@link URI}.
      */
-    public URI redirectUri();
+    Uri redirectUri();
 
     /**
      * Returns the default lifetime of an access token.
      *
      * @return A {@link Duration}.
      */
-    public Duration defaultTokenTtl();
+    Duration defaultTokenTtl();
 }

--- a/src/main/java/org/dmfs/oauth2/client/OAuth2InteractiveGrant.java
+++ b/src/main/java/org/dmfs/oauth2/client/OAuth2InteractiveGrant.java
@@ -19,6 +19,7 @@ package org.dmfs.oauth2.client;
 import org.dmfs.httpessentials.client.HttpRequestExecutor;
 import org.dmfs.httpessentials.exceptions.ProtocolError;
 import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.rfc3986.Uri;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -54,7 +55,7 @@ public interface OAuth2InteractiveGrant extends OAuth2Grant
      * @throws ProtocolException
      *         If the redirectUri is invalid.
      */
-    public OAuth2InteractiveGrant withRedirect(URI redirectUri) throws ProtocolError, ProtocolException;
+    public OAuth2InteractiveGrant withRedirect(Uri redirectUri) throws ProtocolError, ProtocolException;
 
     /**
      * Return a {@link Serializable} state object that can be used to retain the current authentication flow state whenever the original {@link

--- a/src/main/java/org/dmfs/oauth2/client/grants/AuthorizationCodeGrant.java
+++ b/src/main/java/org/dmfs/oauth2/client/grants/AuthorizationCodeGrant.java
@@ -29,6 +29,7 @@ import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.http.requests.AuthorizationCodeTokenRequest;
 import org.dmfs.oauth2.client.pkce.S256CodeChallenge;
 import org.dmfs.oauth2.client.scope.StringScope;
+import org.dmfs.rfc3986.Uri;
 
 import java.io.IOException;
 import java.net.URI;
@@ -89,7 +90,7 @@ public final class AuthorizationCodeGrant implements OAuth2InteractiveGrant
 
 
     @Override
-    public OAuth2InteractiveGrant withRedirect(final URI redirectUri) throws ProtocolError
+    public OAuth2InteractiveGrant withRedirect(final Uri redirectUri) throws ProtocolError
     {
         return new AuthorizedAuthorizationCodeGrant(mClient, redirectUri, mScope, mState, mCodeVerifier);
     }
@@ -119,13 +120,13 @@ public final class AuthorizationCodeGrant implements OAuth2InteractiveGrant
     private final static class AuthorizedAuthorizationCodeGrant implements OAuth2InteractiveGrant
     {
         private final OAuth2Client mClient;
-        private final URI mRedirectUri;
+        private final Uri mRedirectUri;
         private final OAuth2Scope mScope;
         private final String mState;
         private final String mCodeVerifier;
 
 
-        private AuthorizedAuthorizationCodeGrant(OAuth2Client client, URI redirectUri, OAuth2Scope scope, String state, String codeVerifier)
+        private AuthorizedAuthorizationCodeGrant(OAuth2Client client, Uri redirectUri, OAuth2Scope scope, String state, String codeVerifier)
         {
             mClient = client;
             mRedirectUri = redirectUri;
@@ -153,7 +154,7 @@ public final class AuthorizationCodeGrant implements OAuth2InteractiveGrant
 
 
         @Override
-        public OAuth2InteractiveGrant withRedirect(URI redirectUri)
+        public OAuth2InteractiveGrant withRedirect(Uri redirectUri)
         {
             throw new IllegalStateException(
                     "This grant has already been completed. You can't feed another redirect URI.");
@@ -203,16 +204,15 @@ public final class AuthorizationCodeGrant implements OAuth2InteractiveGrant
      */
     private final static class AuthorizedAuthorizationCodeGrantState implements OAuth2InteractiveGrant.OAuth2GrantState
     {
-
         private static final long serialVersionUID = 1L;
 
         private final String mScopeString;
-        private final URI mRedirectUri;
+        private final Uri mRedirectUri;
         private final String mState;
         private final String mCodeVerifier;
 
 
-        public AuthorizedAuthorizationCodeGrantState(OAuth2Scope scope, URI redirectUri, String state, String codeVerifier)
+        public AuthorizedAuthorizationCodeGrantState(OAuth2Scope scope, Uri redirectUri, String state, String codeVerifier)
         {
             mScopeString = scope.toString();
             mRedirectUri = redirectUri;

--- a/src/main/java/org/dmfs/oauth2/client/grants/ImplicitGrant.java
+++ b/src/main/java/org/dmfs/oauth2/client/grants/ImplicitGrant.java
@@ -26,6 +26,7 @@ import org.dmfs.oauth2.client.OAuth2InteractiveGrant;
 import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.scope.StringScope;
 import org.dmfs.oauth2.client.tokens.ImplicitGrantAccessToken;
+import org.dmfs.rfc3986.Uri;
 
 import java.io.IOException;
 import java.net.URI;
@@ -81,7 +82,7 @@ public final class ImplicitGrant implements OAuth2InteractiveGrant
 
 
     @Override
-    public OAuth2InteractiveGrant withRedirect(final URI redirectUri)
+    public OAuth2InteractiveGrant withRedirect(final Uri redirectUri)
     {
         return new AuthorizedImplicitGrant(mClient, redirectUri, mScope, mState);
     }
@@ -111,12 +112,12 @@ public final class ImplicitGrant implements OAuth2InteractiveGrant
     private final static class AuthorizedImplicitGrant implements OAuth2InteractiveGrant
     {
         private final OAuth2Client mClient;
-        private final URI mRedirectUri;
+        private final Uri mRedirectUri;
         private final OAuth2Scope mScope;
         private final String mState;
 
 
-        private AuthorizedImplicitGrant(OAuth2Client client, URI redirectUri, OAuth2Scope scope, String state)
+        private AuthorizedImplicitGrant(OAuth2Client client, Uri redirectUri, OAuth2Scope scope, String state)
         {
             mClient = client;
             mRedirectUri = redirectUri;
@@ -140,7 +141,7 @@ public final class ImplicitGrant implements OAuth2InteractiveGrant
 
 
         @Override
-        public OAuth2InteractiveGrant withRedirect(URI redirectUri)
+        public OAuth2InteractiveGrant withRedirect(Uri redirectUri)
         {
             throw new IllegalStateException(
                     "This grant has already been completed. You can't feed another redirect URI.");
@@ -189,12 +190,12 @@ public final class ImplicitGrant implements OAuth2InteractiveGrant
     {
         private static final long serialVersionUID = 1L;
 
-        private final URI mRedirectUri;
+        private final Uri mRedirectUri;
         private final String mScopeString;
         private final String mState;
 
 
-        private AuthorizedImplicitGrantState(URI redirectUri, OAuth2Scope scope, String state)
+        private AuthorizedImplicitGrantState(Uri redirectUri, OAuth2Scope scope, String state)
         {
             mRedirectUri = redirectUri;
             mScopeString = scope.toString();

--- a/src/main/java/org/dmfs/oauth2/client/http/requests/AuthorizationCodeTokenRequest.java
+++ b/src/main/java/org/dmfs/oauth2/client/http/requests/AuthorizationCodeTokenRequest.java
@@ -20,8 +20,7 @@ import org.dmfs.httpessentials.client.HttpRequestEntity;
 import org.dmfs.oauth2.client.OAuth2AuthCodeAuthorization;
 import org.dmfs.oauth2.client.http.entities.XWwwFormUrlEncodedEntity;
 import org.dmfs.oauth2.client.utils.ImmutableEntry;
-
-import java.net.URI;
+import org.dmfs.rfc3986.Uri;
 
 
 /**
@@ -33,7 +32,7 @@ public final class AuthorizationCodeTokenRequest extends AbstractAccessTokenRequ
 {
     private final ImmutableEntry GRANT_TYPE = new ImmutableEntry("grant_type", "authorization_code");
     private final OAuth2AuthCodeAuthorization mAuthorization;
-    private final URI mRedirectUri;
+    private final Uri mRedirectUri;
     private final String mCodeVerifier;
 
 
@@ -46,7 +45,7 @@ public final class AuthorizationCodeTokenRequest extends AbstractAccessTokenRequ
      * @param codeVerifier
      *         The code verifier that was send with the authorization request.
      */
-    public AuthorizationCodeTokenRequest(OAuth2AuthCodeAuthorization authorization, URI redirectUri, String codeVerifier)
+    public AuthorizationCodeTokenRequest(OAuth2AuthCodeAuthorization authorization, Uri redirectUri, String codeVerifier)
     {
         super(authorization.scope());
         mAuthorization = authorization;
@@ -60,7 +59,7 @@ public final class AuthorizationCodeTokenRequest extends AbstractAccessTokenRequ
     {
         return new XWwwFormUrlEncodedEntity(GRANT_TYPE,
                 new ImmutableEntry("code", mAuthorization.code()),
-                new ImmutableEntry("redirect_uri", mRedirectUri.toASCIIString()),
+                new ImmutableEntry("redirect_uri", mRedirectUri.toString()),
                 new ImmutableEntry("code_verifier", mCodeVerifier));
     }
 }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
@@ -26,10 +26,10 @@ import org.dmfs.httpessentials.types.UrlFormEncodedKeyValues;
 import org.dmfs.oauth2.client.OAuth2AccessToken;
 import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.scope.StringScope;
+import org.dmfs.rfc3986.Uri;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 
-import java.net.URI;
 import java.util.NoSuchElementException;
 
 
@@ -99,9 +99,9 @@ public final class ImplicitGrantAccessToken implements OAuth2AccessToken
      * @throws ProtocolException
      *         If the state doesn't match the one returned by the server.
      */
-    public ImplicitGrantAccessToken(URI redirectUri, OAuth2Scope scope, String state, Duration defaultExpiresIn) throws ProtocolException
+    public ImplicitGrantAccessToken(Uri redirectUri, OAuth2Scope scope, String state, Duration defaultExpiresIn) throws ProtocolException
     {
-        mRedirectUriFragment = new UrlFormEncodedKeyValues(redirectUri.getFragment());
+        mRedirectUriFragment = new UrlFormEncodedKeyValues(redirectUri.fragment().toString());
         if (!state.equals(mRedirectUriFragment.firstParameter(STATE, "")))
         {
             throw new ProtocolException("State in redirect uri doesn't match the original state!");

--- a/src/test/java/org/dmfs/oauth2/client/BasicOAuth2AuthCodeAuthorizationTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/BasicOAuth2AuthCodeAuthorizationTest.java
@@ -18,9 +18,8 @@ package org.dmfs.oauth2.client;
 
 import org.dmfs.httpessentials.exceptions.ProtocolException;
 import org.dmfs.oauth2.client.scope.BasicScope;
+import org.dmfs.rfc3986.uris.StringUri;
 import org.junit.Test;
-
-import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,7 +32,10 @@ public class BasicOAuth2AuthCodeAuthorizationTest
     @Test(expected = ProtocolException.class)
     public void invalidState() throws Exception
     {
-        new BasicOAuth2AuthCodeAuthorization(URI.create("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"), new BasicScope("scope"), "abc");
+        new BasicOAuth2AuthCodeAuthorization(
+                new StringUri("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"),
+                new BasicScope("scope"),
+                "abc");
     }
 
 
@@ -41,7 +43,9 @@ public class BasicOAuth2AuthCodeAuthorizationTest
     public void code() throws Exception
     {
         assertEquals("SplxlOBeZQQYbYS6WxSbIA",
-                new BasicOAuth2AuthCodeAuthorization(URI.create("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"), new BasicScope("scope"),
+                new BasicOAuth2AuthCodeAuthorization(
+                        new StringUri("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"),
+                        new BasicScope("scope"),
                         "xyz").code());
     }
 
@@ -50,7 +54,9 @@ public class BasicOAuth2AuthCodeAuthorizationTest
     public void scope() throws Exception
     {
         assertEquals(new BasicScope("scope"),
-                new BasicOAuth2AuthCodeAuthorization(URI.create("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"), new BasicScope("scope"),
+                new BasicOAuth2AuthCodeAuthorization(
+                        new StringUri("https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"),
+                        new BasicScope("scope"),
                         "xyz").scope());
     }
 

--- a/src/test/java/org/dmfs/oauth2/client/BasicOAuth2AuthorizationRequestTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/BasicOAuth2AuthorizationRequestTest.java
@@ -18,6 +18,7 @@ package org.dmfs.oauth2.client;
 
 import org.dmfs.oauth2.client.scope.BasicScope;
 import org.dmfs.oauth2.client.scope.EmptyScope;
+import org.dmfs.rfc3986.uris.StringUri;
 import org.junit.Test;
 
 import java.net.URI;
@@ -97,7 +98,7 @@ public class BasicOAuth2AuthorizationRequestTest
                 new BasicOAuth2AuthorizationRequest("code",
                         EmptyScope.INSTANCE, "1234")
                         .withClientId("abcd")
-                        .withRedirectUri(URI.create("http://localhost:1234"))
+                        .withRedirectUri(new StringUri("http://localhost:1234"))
                         .authorizationUri(URI.create("http://example.com/auth")));
         assertEquals(URI.create(
                 "http://example.com/auth?response_type=code&scope=calendar&state=1234&client_id=xyz&redirect_uri=http%3A%2F%2Flocalhost%3A1234"),
@@ -105,7 +106,7 @@ public class BasicOAuth2AuthorizationRequestTest
                         "code", new BasicScope("calendar"), "1234")
                         .withClientId("abcd")
                         .withClientId("xyz")
-                        .withRedirectUri(URI.create("http://localhost:1234"))
+                        .withRedirectUri(new StringUri("http://localhost:1234"))
                         .authorizationUri(URI.create("http://example.com/auth")));
         assertEquals(
                 URI.create(
@@ -113,7 +114,7 @@ public class BasicOAuth2AuthorizationRequestTest
                 new BasicOAuth2AuthorizationRequest("code",
                         new BasicScope("calendar", "test", "http://example.com/contacts"), "1234")
                         .withClientId("ab:d")
-                        .withRedirectUri(URI.create("http://localhost:1234"))
+                        .withRedirectUri(new StringUri("http://localhost:1234"))
                         .authorizationUri(URI.create("http://example.com/auth")));
     }
 }

--- a/src/test/java/org/dmfs/oauth2/client/http/decorators/BasicAuthHeaderDecorationTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/http/decorators/BasicAuthHeaderDecorationTest.java
@@ -58,17 +58,20 @@ public class BasicAuthHeaderDecorationTest
         assertTrue(result.contains(HttpHeaders.CONTENT_LENGTH));
     }
 
+
     @Test(expected = IllegalArgumentException.class)
     public void test_whenUsernameIsNull_shouldThrowException() throws Exception
     {
         new BasicAuthHeaderDecoration(null, "pw");
     }
 
+
     @Test(expected = IllegalArgumentException.class)
     public void test_whenPasswordIsNull_shouldThrowException() throws Exception
     {
         new BasicAuthHeaderDecoration("user name", null);
     }
+
 
     @Test
     public void test_thatExistingAuthHeaderIsOverridden() throws Exception

--- a/src/test/java/org/dmfs/oauth2/client/http/entities/XWwwFormUrlEncodedEntityTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/http/entities/XWwwFormUrlEncodedEntityTest.java
@@ -139,6 +139,7 @@ public class XWwwFormUrlEncodedEntityTest
                 new XWwwFormUrlEncodedEntity(new ImmutableEntry("key&with&and", "value&with&and")).toString());
     }
 
+
     @Test
     public void testIgnoreEntries_whenEntryIsNull_orKeyIsNullOrEmpty_orValueIsNull()
     {

--- a/src/test/java/org/dmfs/oauth2/client/http/responsehandlers/TokenErrorResponseHandlerTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/http/responsehandlers/TokenErrorResponseHandlerTest.java
@@ -30,7 +30,9 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 
 /**

--- a/src/test/java/org/dmfs/oauth2/client/scope/BasicScopeTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/scope/BasicScopeTest.java
@@ -18,7 +18,9 @@ package org.dmfs.oauth2.client.scope;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class BasicScopeTest

--- a/src/test/java/org/dmfs/oauth2/client/scope/EmptyScopeTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/scope/EmptyScopeTest.java
@@ -18,7 +18,9 @@ package org.dmfs.oauth2.client.scope;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class EmptyScopeTest

--- a/src/test/java/org/dmfs/oauth2/client/scope/StringScopeTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/scope/StringScopeTest.java
@@ -18,7 +18,9 @@ package org.dmfs.oauth2.client.scope;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class StringScopeTest


### PR DESCRIPTION
Switch to a new (currently very basic) URI implementation that supports URIs with a scheme but without authority. This is necessary to support custom redirect URLs like `com.example:`. Java's URI implementaion refuses to parse these, but as of RFC 3986 they are perfectly valid.

Implementors note: once the new URI library is more complete and mature we should switch the entire stack from Java's `URI` to `org.dmfs:rfc3986-uri`. At this time only the redirect URI uses the new type.