### PR TITLE
Let JsonAccessToken return the response scope, if present. Fixes #36

### DIFF
--- a/src/main/java/org/dmfs/oauth2/client/scope/StringScope.java
+++ b/src/main/java/org/dmfs/oauth2/client/scope/StringScope.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.oauth2.client.scope;
 
+import org.dmfs.iterables.Split;
 import org.dmfs.iterators.CsvIterator;
 import org.dmfs.oauth2.client.OAuth2Scope;
 
@@ -61,9 +62,12 @@ public final class StringScope implements OAuth2Scope
     @Override
     public int tokenCount()
     {
+        if (mScope.isEmpty())
+        {
+            return 0;
+        }
         int count = 0;
-        Iterator<String> tokenIterator = new CsvIterator(mScope, ' ');
-        while (tokenIterator.hasNext())
+        for (CharSequence token : new Split(mScope, ' '))
         {
             count += 1;
         }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -17,8 +17,12 @@
 package org.dmfs.oauth2.client.tokens;
 
 import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.iterators.Function;
 import org.dmfs.oauth2.client.OAuth2AccessToken;
 import org.dmfs.oauth2.client.OAuth2Scope;
+import org.dmfs.oauth2.client.scope.StringScope;
+import org.dmfs.optional.NullSafe;
+import org.dmfs.optional.decorators.Mapped;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 import org.json.JSONException;
@@ -118,7 +122,19 @@ public final class JsonAccessToken implements OAuth2AccessToken
     @Override
     public OAuth2Scope scope() throws ProtocolException
     {
-        return mScope;
+        return new Mapped<>(new OAuth2ScopeFunction(), new NullSafe<>(mTokenResponse.optString("scope", null))).value(mScope);
     }
 
+
+    /**
+     * A {@link Function} which converts a String into an {@link OAuth2Scope}.
+     */
+    private static class OAuth2ScopeFunction implements Function<String, OAuth2Scope>
+    {
+        @Override
+        public OAuth2Scope apply(String argument)
+        {
+            return new StringScope(argument);
+        }
+    }
 }

--- a/src/test/java/org/dmfs/oauth2/client/scope/StringScopeTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/scope/StringScopeTest.java
@@ -18,13 +18,23 @@ package org.dmfs.oauth2.client.scope;
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 
 public class StringScopeTest
 {
+    @Test
+    public void testTokenCount() throws Exception
+    {
+        assertThat(new StringScope("").tokenCount(), is(0));
+        assertThat(new StringScope("test").tokenCount(), is(1));
+        assertThat(new StringScope("test calendar").tokenCount(), is(2));
+    }
+
 
     @Test
     public void testIsEmpty()

--- a/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.oauth2.client.tokens;
+
+import org.dmfs.oauth2.client.OAuth2Scope;
+import org.dmfs.oauth2.client.scope.StringScope;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class JsonAccessTokenTest
+{
+    @Test
+    public void testNoScope() throws Exception
+    {
+        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
+        JSONObject jsonObject = new JSONObject();
+        assertThat(new JsonAccessToken(jsonObject, dummyScope).scope(), sameInstance(dummyScope));
+    }
+
+
+    @Test
+    public void testScope() throws Exception
+    {
+        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
+        // note: we don't use a mock here, because there are multiple ways to get a String value and we don't want to make assumptions on that
+        JSONObject jsonObject = new JSONObject("{\"scope\": \"scope1 scope2\"}");
+
+        assertThat(new JsonAccessToken(jsonObject, dummyScope).scope(), Matchers.<OAuth2Scope>is(new StringScope("scope1 scope2")));
+    }
+
+}


### PR DESCRIPTION
[RFC 6749](https://tools.ietf.org/html/rfc6749#section-5.1) states:
> scope
>         OPTIONAL, if identical to the scope requested by the client;
>         otherwise, REQUIRED.  The scope of the access token as
>         described by Section 3.3.

So if there is a scope in the response we should return that and fall back to the provided one otherwise.

Also fixes an issue in StringScope.tokenCount() which resulted in an infinite loop.