### PR TITLE
Add access to json payload in JsonAccessToken

### DIFF
--- a/src/main/java/org/dmfs/oauth2/client/OAuth2AccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/OAuth2AccessToken.java
@@ -17,6 +17,7 @@
 package org.dmfs.oauth2.client;
 
 import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.optional.Optional;
 import org.dmfs.rfc5545.DateTime;
 
 import java.util.NoSuchElementException;
@@ -82,4 +83,13 @@ public interface OAuth2AccessToken
      * @throws ProtocolException
      */
     public OAuth2Scope scope() throws ProtocolException;
+
+    /**
+     * Returns a value stored in the token response under the {@code parameterName}.
+     *
+     * @param parameterName the key under which the value is stored in the response
+     *
+     * @throws ProtocolException
+     */
+    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException;
 }

--- a/src/main/java/org/dmfs/oauth2/client/OAuth2AccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/OAuth2AccessToken.java
@@ -88,8 +88,6 @@ public interface OAuth2AccessToken
      * Returns a value stored in the token response under the {@code parameterName}.
      *
      * @param parameterName the key under which the value is stored in the response
-     *
-     * @throws ProtocolException
      */
-    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException;
+    public Optional<CharSequence> extraParameter(final String parameterName);
 }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
@@ -136,7 +136,7 @@ public final class ImplicitGrantAccessToken implements OAuth2AccessToken
     }
 
     @Override
-    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException
+    public Optional<CharSequence> extraParameter(final String parameterName)
     {
         return new OptionalParameter<>(new BasicParameterType<>(parameterName, TextValueType.INSTANCE), mRedirectUriParameters);
     }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessToken.java
@@ -19,11 +19,14 @@ package org.dmfs.oauth2.client.tokens;
 import org.dmfs.httpessentials.exceptions.ProtocolException;
 import org.dmfs.oauth2.client.OAuth2AccessToken;
 import org.dmfs.oauth2.client.OAuth2Scope;
+import org.dmfs.optional.Optional;
 import org.dmfs.rfc3986.Uri;
 import org.dmfs.rfc3986.parameters.ParameterList;
 import org.dmfs.rfc3986.parameters.adapters.OptionalParameter;
 import org.dmfs.rfc3986.parameters.adapters.TextParameter;
 import org.dmfs.rfc3986.parameters.adapters.XwfueParameterList;
+import org.dmfs.rfc3986.parameters.parametertypes.BasicParameterType;
+import org.dmfs.rfc3986.parameters.valuetypes.TextValueType;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 
@@ -130,5 +133,11 @@ public final class ImplicitGrantAccessToken implements OAuth2AccessToken
     public OAuth2Scope scope() throws ProtocolException
     {
         return new OptionalParameter<>(SCOPE, mRedirectUriParameters).value(mScope);
+    }
+
+    @Override
+    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException
+    {
+        return new OptionalParameter<>(new BasicParameterType<>(parameterName, TextValueType.INSTANCE), mRedirectUriParameters);
     }
 }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -22,6 +22,7 @@ import org.dmfs.oauth2.client.OAuth2AccessToken;
 import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.scope.StringScope;
 import org.dmfs.optional.NullSafe;
+import org.dmfs.optional.Optional;
 import org.dmfs.optional.decorators.Mapped;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
@@ -125,9 +126,10 @@ public final class JsonAccessToken implements OAuth2AccessToken
         return new Mapped<>(new OAuth2ScopeFunction(), new NullSafe<>(mTokenResponse.optString("scope", null))).value(mScope);
     }
 
-    public JSONObject tokenResponse()
+    @Override
+    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException
     {
-        return this.mTokenResponse;
+        return new NullSafe<CharSequence>(mTokenResponse.optString(parameterName, null));
     }
 
 

--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -127,7 +127,7 @@ public final class JsonAccessToken implements OAuth2AccessToken
     }
 
     @Override
-    public Optional<CharSequence> extraParameter(final String parameterName) throws ProtocolException
+    public Optional<CharSequence> extraParameter(final String parameterName)
     {
         return new NullSafe<CharSequence>(mTokenResponse.optString(parameterName, null));
     }

--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -125,6 +125,11 @@ public final class JsonAccessToken implements OAuth2AccessToken
         return new Mapped<>(new OAuth2ScopeFunction(), new NullSafe<>(mTokenResponse.optString("scope", null))).value(mScope);
     }
 
+    public JSONObject tokenResponse()
+    {
+        return this.mTokenResponse;
+    }
+
 
     /**
      * A {@link Function} which converts a String into an {@link OAuth2Scope}.

--- a/src/test/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessTokenTest.java
@@ -32,7 +32,7 @@ public class ImplicitGrantAccessTokenTest {
     public void testExtraParameter() throws Exception
     {
         assertThat(new ImplicitGrantAccessToken(
-                        new LazyUri(new Precoded("http://localhost?state=1&key=value")),
+                        new LazyUri(new Precoded("http://localhost#state=1&key=value")),
                         new EmptyScope(),
                         "1",
                         new Duration(1, 1, 0)).extraParameter("key"),
@@ -43,7 +43,7 @@ public class ImplicitGrantAccessTokenTest {
     public void testExtraParameterDoesNotExist() throws Exception
     {
         assertThat(new ImplicitGrantAccessToken(
-                        new LazyUri(new Precoded("http://localhost?state=1&key=value")),
+                        new LazyUri(new Precoded("http://localhost#state=1&key=value")),
                         new EmptyScope(),
                         "1",
                         new Duration(1, 1, 0)).extraParameter("idToken"),

--- a/src/test/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/ImplicitGrantAccessTokenTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.oauth2.client.tokens;
+
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.dmfs.jems.hamcrest.matchers.PresentMatcher;
+import org.dmfs.oauth2.client.scope.EmptyScope;
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
+import org.dmfs.rfc5545.Duration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+public class ImplicitGrantAccessTokenTest {
+
+    @Test
+    public void testExtraParameter() throws Exception
+    {
+        assertThat(new ImplicitGrantAccessToken(
+                        new LazyUri(new Precoded("http://localhost?state=1&key=value")),
+                        new EmptyScope(),
+                        "1",
+                        new Duration(1, 1, 0)).extraParameter("key"),
+                PresentMatcher.<CharSequence>isPresent("value"));
+    }
+
+    @Test
+    public void testExtraParameterDoesNotExist() throws Exception
+    {
+        assertThat(new ImplicitGrantAccessToken(
+                        new LazyUri(new Precoded("http://localhost?state=1&key=value")),
+                        new EmptyScope(),
+                        "1",
+                        new Duration(1, 1, 0)).extraParameter("idToken"),
+                AbsentMatcher.<CharSequence>isAbsent());
+    }
+
+}

--- a/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
@@ -51,4 +51,14 @@ public class JsonAccessTokenTest
         assertThat(new JsonAccessToken(jsonObject, dummyScope).scope(), Matchers.<OAuth2Scope>is(new StringScope("scope1 scope2")));
     }
 
+    @Test
+    public void testCustomPayload() throws Exception
+    {
+        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
+        JSONObject jsonObject = new JSONObject("{\"idToken\":\"id_token_value\"}");
+
+        String idToken = new JsonAccessToken(jsonObject, dummyScope).tokenResponse().getString("idToken");
+        assertThat(idToken, Matchers.is("id_token_value"));
+    }
+
 }

--- a/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
@@ -16,9 +16,10 @@
 
 package org.dmfs.oauth2.client.tokens;
 
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.dmfs.jems.hamcrest.matchers.PresentMatcher;
 import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.scope.StringScope;
-import org.dmfs.optional.Optional;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -55,23 +56,15 @@ public class JsonAccessTokenTest
     @Test
     public void testCustomPayload() throws Exception
     {
-        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
-        JSONObject jsonObject = new JSONObject("{\"idToken\":\"id_token_value\"}");
-
-        Optional<CharSequence> parameter = new JsonAccessToken(jsonObject, dummyScope).extraParameter("idToken");
-        assertThat(parameter.isPresent(), Matchers.is(true));
-        assertThat(parameter.value().toString(), Matchers.is("id_token_value"));
+        assertThat(new JsonAccessToken(new JSONObject("{\"idToken\":\"id_token_value\"}"), dummy(OAuth2Scope.class))
+                .extraParameter("idToken"), PresentMatcher.<CharSequence>isPresent("id_token_value"));
     }
 
     @Test
     public void testCustomPayloadWithNonExistingParameter() throws Exception
     {
-        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
-        JSONObject jsonObject = new JSONObject("{}");
-
-        Optional<CharSequence> parameter = new JsonAccessToken(jsonObject, dummyScope).extraParameter("idToken");
-        assertThat(parameter.isPresent(), Matchers.is(false));
-        assertThat(parameter.value("default").toString(), Matchers.is("default"));
+        assertThat(new JsonAccessToken(new JSONObject("{}"), dummy(OAuth2Scope.class)).extraParameter("idToken"),
+                AbsentMatcher.<CharSequence>isAbsent());
     }
 
 }

--- a/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
@@ -18,6 +18,7 @@ package org.dmfs.oauth2.client.tokens;
 
 import org.dmfs.oauth2.client.OAuth2Scope;
 import org.dmfs.oauth2.client.scope.StringScope;
+import org.dmfs.optional.Optional;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -57,8 +58,20 @@ public class JsonAccessTokenTest
         OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
         JSONObject jsonObject = new JSONObject("{\"idToken\":\"id_token_value\"}");
 
-        String idToken = new JsonAccessToken(jsonObject, dummyScope).tokenResponse().getString("idToken");
-        assertThat(idToken, Matchers.is("id_token_value"));
+        Optional<CharSequence> parameter = new JsonAccessToken(jsonObject, dummyScope).extraParameter("idToken");
+        assertThat(parameter.isPresent(), Matchers.is(true));
+        assertThat(parameter.value().toString(), Matchers.is("id_token_value"));
+    }
+
+    @Test
+    public void testCustomPayloadWithNonExistingParameter() throws Exception
+    {
+        OAuth2Scope dummyScope = dummy(OAuth2Scope.class);
+        JSONObject jsonObject = new JSONObject("{}");
+
+        Optional<CharSequence> parameter = new JsonAccessToken(jsonObject, dummyScope).extraParameter("idToken");
+        assertThat(parameter.isPresent(), Matchers.is(false));
+        assertThat(parameter.value("default").toString(), Matchers.is("default"));
     }
 
 }


### PR DESCRIPTION
The following pull request adds a simple accessor method to the `JsonAccessToken` that provides the raw JSON response to the library user.

There are quite a few token responses that contain extra data valuable or mandatory for the library user. Since there is no exposure to that data, a simple accessor method like the one provided in this pull request fixes that problem,

This also potentially closes the #20 issue.