### PR TITLE
Support URI redirect uris.

### DIFF
--- a/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
+++ b/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
@@ -26,6 +26,8 @@ import org.dmfs.httpessentials.executors.useragent.Branded;
 import org.dmfs.httpessentials.types.Product;
 import org.dmfs.httpessentials.types.VersionedProduct;
 import org.dmfs.rfc3986.Uri;
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
 import org.dmfs.rfc5545.Duration;
 
 import java.io.IOException;
@@ -46,6 +48,12 @@ public final class BasicOAuth2Client implements OAuth2Client
     private final OAuth2AuthorizationProvider mProvider;
     private final OAuth2ClientCredentials mCredentials;
     private final Uri mRedirectUri;
+
+
+    public BasicOAuth2Client(OAuth2AuthorizationProvider provider, OAuth2ClientCredentials credentials, URI redirectUri)
+    {
+        this(provider, credentials, new LazyUri(new Precoded(redirectUri.toString())));
+    }
 
 
     public BasicOAuth2Client(OAuth2AuthorizationProvider provider, OAuth2ClientCredentials credentials, Uri redirectUri)


### PR DESCRIPTION
In the past redirect URIs were provided as `java.net.URI` values. A few commits back we switched to `org.dmfs.rfc3986.Uri`. However, for convenience (and backwards compatibility) it would be good to provide the old constructor as a secondary constructor.