### PR TITLE
Evaluate redirect URI lazily, implements #69

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ tasks.withType(Jar) {
     }
 }
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 configurations {
     pom

--- a/oauth2-providers/build.gradle
+++ b/oauth2-providers/build.gradle
@@ -28,7 +28,7 @@ def gitVersion = { ->
 group 'org.dmfs'
 version gitVersion()
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 configurations {
     pom

--- a/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
+++ b/src/main/java/org/dmfs/oauth2/client/BasicOAuth2Client.java
@@ -25,6 +25,7 @@ import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
 import org.dmfs.httpessentials.executors.useragent.Branded;
 import org.dmfs.httpessentials.types.Product;
 import org.dmfs.httpessentials.types.VersionedProduct;
+import org.dmfs.oauth2.client.utils.LazyCharSequence;
 import org.dmfs.rfc3986.Uri;
 import org.dmfs.rfc3986.encoding.Precoded;
 import org.dmfs.rfc3986.uris.LazyUri;
@@ -52,7 +53,7 @@ public final class BasicOAuth2Client implements OAuth2Client
 
     public BasicOAuth2Client(OAuth2AuthorizationProvider provider, OAuth2ClientCredentials credentials, URI redirectUri)
     {
-        this(provider, credentials, new LazyUri(new Precoded(redirectUri.toString())));
+        this(provider, credentials, new LazyUri(new Precoded(new LazyCharSequence(redirectUri))));
     }
 
 

--- a/src/main/java/org/dmfs/oauth2/client/utils/LazyCharSequence.java
+++ b/src/main/java/org/dmfs/oauth2/client/utils/LazyCharSequence.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.oauth2.client.utils;
+
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.Frozen;
+
+
+/**
+ * A {@link CharSequence} which is evaluated lazily.
+ *
+ * @author Marten Gajda
+ */
+public final class LazyCharSequence implements CharSequence
+{
+
+    private final Single<CharSequence> mDelegate;
+
+
+    /**
+     * Creates a {@link CharSequence} which delegates to the {@link Object#toString()} method of the delegate.
+     */
+    public LazyCharSequence(Object delegate)
+    {
+        this(() -> delegate.toString());
+    }
+
+
+    public LazyCharSequence(Single<CharSequence> delegate)
+    {
+        mDelegate = new Frozen<>(delegate);
+    }
+
+
+    @Override
+    public int length()
+    {
+        return mDelegate.value().length();
+    }
+
+
+    @Override
+    public char charAt(int i)
+    {
+        return mDelegate.value().charAt(i);
+    }
+
+
+    @Override
+    public CharSequence subSequence(int start, int end)
+    {
+        return mDelegate.value().subSequence(start, end);
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return mDelegate.value().toString();
+    }
+}


### PR DESCRIPTION
Evaluating the redirect URI of BasicOAuth2Client lazily allows passing `null`without breaking non-interactive grant types.