### PR TITLE
Option to access raw token response by client

### DIFF
--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -135,6 +135,19 @@ public final class JsonAccessToken implements OAuth2AccessToken
         return new NullSafe<>(mTokenResponse.optString(parameterName, null));
     }
 
+    /**
+     * Returns the raw token response given by OAuth provider.
+     *
+     * @param executor
+     *     An {@link HttpRequestExecutor} to execute the request.
+     *
+     * @return An {@link org.json.JSONObject}.
+     *
+     */
+    public JSONObject rawResponse()
+    {
+        return new JSONObject(mTokenResponse.toMap());
+    }
 
     /**
      * A {@link Function} which converts a String into an {@link OAuth2Scope}.

--- a/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
+++ b/src/main/java/org/dmfs/oauth2/client/tokens/JsonAccessToken.java
@@ -138,9 +138,6 @@ public final class JsonAccessToken implements OAuth2AccessToken
     /**
      * Returns the raw token response given by OAuth provider.
      *
-     * @param executor
-     *     An {@link HttpRequestExecutor} to execute the request.
-     *
      * @return An {@link org.json.JSONObject}.
      *
      */

--- a/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
+++ b/src/test/java/org/dmfs/oauth2/client/tokens/JsonAccessTokenTest.java
@@ -62,6 +62,15 @@ public class JsonAccessTokenTest
             .extraParameter("idToken"), is(present(Matchers.<CharSequence>hasToString("id_token_value"))));
     }
 
+    @Test
+    public void testRawResponse() throws Exception
+    {
+        JSONObject originalJsonObject = new JSONObject("{\"idToken\":\"id_token_value\"}");
+        assertThat(new JsonAccessToken(originalJsonObject, dummy(OAuth2Scope.class))
+            .rawResponse(), is(originalJsonObject)));
+    }
+
+
 
     @Test
     public void testCustomPayloadWithNonExistingParameter() throws Exception


### PR DESCRIPTION
**Requirement:** The client may need to store/access the raw token response received from the OAuth provider.  

**Existing possible solution:** The `extraParameter` method already gives an option to get properties from the raw JSON response given by the OAuth provider, but it requires the `key` should be already known. Additionally, the whole raw response cannot be accessed directly. 

**Proposed solution:** A method is added to `JsonAccessToken.java` that returns a deep cloned raw JSON response, as received from the OAuth provider. Deep cloning is to prevent the accidental modification of raw response.

